### PR TITLE
Improve property template

### DIFF
--- a/templates/web-api-property.md
+++ b/templates/web-api-property.md
@@ -16,7 +16,7 @@ tags:
 } %><% if (securecontext) { 
 %>{{SecureContext_Header}}<% } %>
 
-The <% if (static) {%>static <% }%>**`<%= membername %>`** property of the {{DOMxRef("iface")}} interface TOWRITE: the end of the summary paragraph
+The **`<%= membername %>`** <% if (static) {%>static <% }%>property of the {{DOMxRef("iface")}} interface TOWRITE: the end of the summary paragraph
 
 ## Value
 
@@ -33,4 +33,3 @@ TOWRITE: Write a short example demonstrating the use of this property. If not pe
 ## Browser compatibility
 
 {{Compat}}
-

--- a/templates/web-api-property.md
+++ b/templates/web-api-property.md
@@ -1,29 +1,30 @@
 ---
 title: <%= iface %>.<%= membername %>
 slug: Web/API/<%= iface %>/<%= membername %>
-page-type: web-api-<% if (static) { %>static<% } else { %>instance<% } %>-property
-<% if (experimental) { %>
+page-type: web-api-<%
+if (static) { %>static<% 
+} else { %>instance<% 
+} %>-property<% 
+if (experimental) { %>
 tags:
 - experimental
-<% } %>
-browser-compat: api.<%= iface %>.<%= membername %>
+<% } 
+%>browser-compat: api.<%= iface %>.<%= membername %>
 ---
-{{APIRef("<%=groupdataname%>")}}
-<% if (experimental) { %>
-{{SeeCompatTable}}
-<% } %>
-<% if (securecontext) { %>
-{{SecureContext_Header}}
-<% } %>
+{{APIRef("<%=groupdataname%>")}}<% if (experimental) { 
+%>{{SeeCompatTable}}<% 
+} %><% if (securecontext) { 
+%>{{SecureContext_Header}}<% } %>
 
-TOWRITE: Summary paragraph
-
+The <% if (static) {%>static <% }%>**<%= membername %>** property of the {{DOMxRef("iface")}} interface TOWRITE: the end of the summary paragraph
 
 ## Value
 
 TOWRITE: Include a description of the property's value, including data type and what it represents.
 
 ## Examples
+
+TOWRITE: Write a short example demonstrating the use of this property. If not pertinent, delete the whole section
 
 ## Specifications
 

--- a/templates/web-api-property.md
+++ b/templates/web-api-property.md
@@ -16,7 +16,7 @@ tags:
 } %><% if (securecontext) { 
 %>{{SecureContext_Header}}<% } %>
 
-The <% if (static) {%>static <% }%>**<%= membername %>** property of the {{DOMxRef("iface")}} interface TOWRITE: the end of the summary paragraph
+The <% if (static) {%>static <% }%>**`<%= membername %>`** property of the {{DOMxRef("iface")}} interface TOWRITE: the end of the summary paragraph
 
 ## Value
 


### PR DESCRIPTION
- Remove extraneous empty lines (triggering Markdownlint)
- Add the standard beginning of the summary paragraph
- Add a TOWRITE section with basic info for the _Examples_ section.